### PR TITLE
Fix `fold1` and `foldMap1`

### DIFF
--- a/src/Data/List/Pointed.purs
+++ b/src/Data/List/Pointed.purs
@@ -52,10 +52,10 @@ instance traversablePointed ∷ Traversable Pointed where
 
 instance foldable1Pointed ∷ Foldable1 Pointed where
   fold1 (Pointed { suffix, reversedPrefix, focus }) =
-    foldr (<>) (foldl (<>) focus reversedPrefix) suffix
+    foldl (<>) (foldl (flip (<>)) focus reversedPrefix) suffix
 
   foldMap1 f (Pointed { suffix, reversedPrefix, focus }) =
-    foldr (\e r → f e <> r) (foldl (\r e → r <> f e) (f focus) reversedPrefix) suffix
+    foldl (\r e → r <> f e) (foldl (\r e → f e <> r) (f focus) reversedPrefix) suffix
 
 instance eqPointed ∷ Eq a ⇒ Eq (Pointed a) where
   eq


### PR DESCRIPTION
This pull request fixes the functions `fold1` and `foldMap1` with the result that the fixed implementations append all elements in the correct order. 😄

```
PSCi, version 0.12.0
Type :? for help

> import Prelude
> import Data.Semigroup.Foldable 
> import Data.List.Pointed 
> map fold1 (prev =<< prev =<< fromFoldable ["1", "2", "3", "4", "5"])
(Just "12345")
```